### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ env:
 language: C
 dist: xenial
 
+arch:
+  - AMD64
+  - ppc64le
+
 before_install:
   - sudo apt-get update -qq
 


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra